### PR TITLE
Updated for Skyrim AE (1.6.323)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,7 +437,7 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "skyrim-search-se"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skyrim-search-se"
-version = "0.1.0"
+version = "0.3.0"
 authors = ["qbx2 <sunyeop97@gmail.com>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Also, You can view your inputs and outputs in log file in `\My Games\Skyrim Spec
 * help command: `ss --help`
 ```
 ss --help
-skyrim-search-se 0.1
-Author: qbx2 / GitHub: https://github.com/qbx2/sse-mod-skyrim-search-se
+skyrim-search-se 0.3
+Author: qbx2/lukasaldersley | GitHub: https://github.com/qbx2/sse-mod-skyrim-search-se
  
 USAGE:
     ss [FLAGS] <SUBCOMMAND>
@@ -142,17 +142,21 @@ ss raw SELECT * FROM npc WHERE form_id > 0xa2c00 AND form_id < 0xa2d00;
 
 ```
 ## Requirements
-- [SKSE64](https://skse.silverlock.org/)
-- SkyrimSE *1.5.97*
+- SkyrimSE *1.6.323*
+- [SKSE64](https://skse.silverlock.org/), matching game version
 
 ## Build Requirements
-- [Rust](https://www.rust-lang.org/) compiler
+- [MinGW64: mingw-w64-install.exe](https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/installer/mingw-w64-install.exe) needs to be installed with the x86_64 option NOT i686, and you need add its bin folder to the PATH system variable
+- [Rust 1.51+](https://www.rust-lang.org/) compiler
 - `rustup target add x86_64-pc-windows-gnu`
 
 ## Build
 ```
 cargo build
 ```
+
+### Credits 
+[kmdreko](https://stackoverflow.com/users/2189130/kmdreko) on Stack Overflow for helping with some Rust problems
 
 ### Disclaimer
 This plugin was not created by, and is not affiliated with, the website SkyrimSearch.com.

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ ss raw SELECT * FROM npc WHERE form_id > 0xa2c00 AND form_id < 0xa2d00;
 - [SKSE64](https://skse.silverlock.org/), matching game version
 
 ## Build Requirements
-- [MinGW64: mingw-w64-install.exe](https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/installer/mingw-w64-install.exe) needs to be installed with the x86_64 option NOT i686, and you need add its bin folder to the PATH system variable
+- [MinGW64: mingw-w64-install.exe (For windows users)](https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/installer/mingw-w64-install.exe) needs to be installed with the x86_64 option NOT i686, and you need add its bin folder to the PATH system variable
 - [Rust 1.51+](https://www.rust-lang.org/) compiler
 - `rustup target add x86_64-pc-windows-gnu`
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -22,8 +22,8 @@ pub const SKYRIM_SEARCH_COMMANDS: [&str; 4] = ["ss", "sss", "skyrimsearch", "sky
 
 pub fn get_clap<'a, 'b>() -> clap::App<'a, 'b> {
     clap::App::new("skyrim-search-se")
-        .version("0.1")
-        .author("Author: qbx2 / GitHub: https://github.com/qbx2/sse-mod-skyrim-search-se")
+        .version("0.3")
+        .author("Author: qbx2/lukasaldersley | GitHub: https://github.com/qbx2/sse-mod-skyrim-search-se")
         .setting(AppSettings::DisableHelpSubcommand)
         .setting(AppSettings::VersionlessSubcommands)
         .setting(AppSettings::SubcommandRequiredElseHelp)

--- a/src/console.rs
+++ b/src/console.rs
@@ -80,7 +80,7 @@ pub(crate) fn print<T: Into<Vec<u8>>>(msg: T) {
 }
 
 pub(crate) unsafe fn init(image_base: usize) -> anyhow::Result<()> {
-    let target_addr = transmute(image_base + 0x2e75f0);
+    let target_addr = transmute(image_base + 0x2fb970);//1.5.97: 0x2e75f0 -> 1.6.318: 0x2fba00 -> addressLib ID: 21890 -> 1.6.323: 0x2fb970
     let process_console_input_hook =
         GenericDetour::<fn(usize, i64, i64, i64)>::new(target_addr, new_process_console_input)
             .context("initialize")?;
@@ -88,8 +88,8 @@ pub(crate) unsafe fn init(image_base: usize) -> anyhow::Result<()> {
     LateStatic::assign(
         &S,
         State {
-            console_context: transmute(image_base + 0x2f000f0),
-            print_to_console: transmute(image_base + 0x85c290),
+            console_context: transmute(image_base + 0x2f9a800),//1.5.97: 0x2f000f0 -> 1.6.318: 0x2f9a800 -> addressLib ID: 401203 -> 1.6.323: 0x2f9a800
+            print_to_console: transmute(image_base + 0x8893c0),//1.5.97: 0x85c290 -> 1.6.318: 0x889650 -> addressLib ID: 51109 -> 1.6.323: 0x8893c0
             process_console_input_hook,
         },
     );

--- a/src/console.rs
+++ b/src/console.rs
@@ -80,7 +80,7 @@ pub(crate) fn print<T: Into<Vec<u8>>>(msg: T) {
 }
 
 pub(crate) unsafe fn init(image_base: usize) -> anyhow::Result<()> {
-    let target_addr = transmute(image_base + 0x2fb970);//1.5.97: 0x2e75f0 -> 1.6.318: 0x2fba00 -> addressLib ID: 21890 -> 1.6.323: 0x2fb970
+    let target_addr = transmute(image_base + 0x2fb970);
     let process_console_input_hook =
         GenericDetour::<fn(usize, i64, i64, i64)>::new(target_addr, new_process_console_input)
             .context("initialize")?;
@@ -88,8 +88,8 @@ pub(crate) unsafe fn init(image_base: usize) -> anyhow::Result<()> {
     LateStatic::assign(
         &S,
         State {
-            console_context: transmute(image_base + 0x2f9a800),//1.5.97: 0x2f000f0 -> 1.6.318: 0x2f9a800 -> addressLib ID: 401203 -> 1.6.323: 0x2f9a800
-            print_to_console: transmute(image_base + 0x8893c0),//1.5.97: 0x85c290 -> 1.6.318: 0x889650 -> addressLib ID: 51109 -> 1.6.323: 0x8893c0
+            console_context: transmute(image_base + 0x2f9a800),
+            print_to_console: transmute(image_base + 0x8893c0),
             process_console_input_hook,
         },
     );

--- a/src/form/achr.rs
+++ b/src/form/achr.rs
@@ -61,7 +61,7 @@ impl TESCharacter {
 }
 
 pub(crate) unsafe fn init(image_base: usize) -> anyhow::Result<()> {
-    let character_vtable = transmute(image_base + 0x1753670);//1.5.97: 0x165da40 -> 1.6.318: 0x1753670 -> addressLib ID: 207886 -> 1.6.323: 0x1753670
+    let character_vtable = transmute(image_base + 0x1753670);
 
     let original_character_load = patch_bytes(
         &(TESCharacter::new_load as usize),

--- a/src/form/achr.rs
+++ b/src/form/achr.rs
@@ -61,7 +61,7 @@ impl TESCharacter {
 }
 
 pub(crate) unsafe fn init(image_base: usize) -> anyhow::Result<()> {
-    let character_vtable = transmute(image_base + 0x165da40);
+    let character_vtable = transmute(image_base + 0x1753670);//1.5.97: 0x165da40 -> 1.6.318: 0x1753670 -> addressLib ID: 207886 -> 1.6.323: 0x1753670
 
     let original_character_load = patch_bytes(
         &(TESCharacter::new_load as usize),

--- a/src/form/cell.rs
+++ b/src/form/cell.rs
@@ -69,7 +69,7 @@ impl TESObjectCELL {
 }
 
 pub(crate) unsafe fn init(image_base: usize) -> anyhow::Result<()> {
-    let cell_vtable = transmute(image_base + 0x1566060);
+    let cell_vtable = transmute(image_base + 0x165dab0);//1.5.97: 0x1566060 -> 1.6.318: 0x165dab0 -> addressLib ID: 190143 -> 1.6.323: 0x165dab0
 
     let original_cell_load = patch_bytes(
         &(TESObjectCELL::new_load as usize),

--- a/src/form/cell.rs
+++ b/src/form/cell.rs
@@ -69,7 +69,7 @@ impl TESObjectCELL {
 }
 
 pub(crate) unsafe fn init(image_base: usize) -> anyhow::Result<()> {
-    let cell_vtable = transmute(image_base + 0x165dab0);//1.5.97: 0x1566060 -> 1.6.318: 0x165dab0 -> addressLib ID: 190143 -> 1.6.323: 0x165dab0
+    let cell_vtable = transmute(image_base + 0x165dab0);
 
     let original_cell_load = patch_bytes(
         &(TESObjectCELL::new_load as usize),

--- a/src/form/mod.rs
+++ b/src/form/mod.rs
@@ -48,8 +48,8 @@ impl TESForm {
 }
 
 pub(crate) unsafe fn init(image_base: usize) -> anyhow::Result<()> {
-    let get_name = transmute(image_base + 0x1a1c00);//1.5.97: 0x196e10 -> 1.6.318: 0x1a1c90 -> addressLib ID: 14720 -> 1.6.323: 0x1a1c00
-    let look_up_by_id = transmute(image_base + 0x19f080);//1.5.97: 0x194230 -> 1.6.318: 0x19f110 -> addressLib ID: 14617 -> 1.6.323: 0x19f080
+    let get_name = transmute(image_base + 0x1a1c00);
+    let look_up_by_id = transmute(image_base + 0x19f080);
 
     LateStatic::assign(
         &S,

--- a/src/form/mod.rs
+++ b/src/form/mod.rs
@@ -48,8 +48,8 @@ impl TESForm {
 }
 
 pub(crate) unsafe fn init(image_base: usize) -> anyhow::Result<()> {
-    let get_name = transmute(image_base + 0x196e10);
-    let look_up_by_id = transmute(image_base + 0x194230);
+    let get_name = transmute(image_base + 0x1a1c00);//1.5.97: 0x196e10 -> 1.6.318: 0x1a1c90 -> addressLib ID: 14720 -> 1.6.323: 0x1a1c00
+    let look_up_by_id = transmute(image_base + 0x19f080);//1.5.97: 0x194230 -> 1.6.318: 0x19f110 -> addressLib ID: 14617 -> 1.6.323: 0x19f080
 
     LateStatic::assign(
         &S,

--- a/src/form/npc.rs
+++ b/src/form/npc.rs
@@ -89,7 +89,7 @@ impl TESNPC {
 }
 
 pub(crate) unsafe fn init(image_base: usize) -> anyhow::Result<()> {
-    let npc_vtable = transmute(image_base + 0x159fcd0);
+    let npc_vtable = transmute(image_base + 0x1697a30);//1.5.97: 0x159fcd0-> 1.6.318: 0x1697a30 -> addressLib ID: 195816 -> 1.6.323: 0x1697a30
 
     output_debug_string(format!("npc set_edid: {:#x}", npc_vtable + 0x198).as_str());
 

--- a/src/form/npc.rs
+++ b/src/form/npc.rs
@@ -89,7 +89,7 @@ impl TESNPC {
 }
 
 pub(crate) unsafe fn init(image_base: usize) -> anyhow::Result<()> {
-    let npc_vtable = transmute(image_base + 0x1697a30);//1.5.97: 0x159fcd0-> 1.6.318: 0x1697a30 -> addressLib ID: 195816 -> 1.6.323: 0x1697a30
+    let npc_vtable = transmute(image_base + 0x1697a30);
 
     output_debug_string(format!("npc set_edid: {:#x}", npc_vtable + 0x198).as_str());
 

--- a/src/form/qust.rs
+++ b/src/form/qust.rs
@@ -234,8 +234,8 @@ impl TESQuest {
 }
 
 pub(crate) unsafe fn init(image_base: usize) -> anyhow::Result<()> {
-    let quest_vtable = transmute(image_base + 0x1699720);//1.5.97: 0x15a1c98 -> 1.6.318: 0x1699720 -> addressLib ID: 195890 -> 1.6.323: 0x1699720
-    let quest_get_description = transmute(image_base + 0x398f70);//1.5.97: 0x382720 -> 1.6.318: 0x399000 -> addressLib ID: 25259 -> 1.6.323: 0x398f70
+    let quest_vtable = transmute(image_base + 0x1699720);
+    let quest_get_description = transmute(image_base + 0x398f70);
 
     let original_quest_load = patch_bytes(
         &(TESQuest::new_load as usize),

--- a/src/form/qust.rs
+++ b/src/form/qust.rs
@@ -234,8 +234,8 @@ impl TESQuest {
 }
 
 pub(crate) unsafe fn init(image_base: usize) -> anyhow::Result<()> {
-    let quest_vtable = transmute(image_base + 0x15a1c98);
-    let quest_get_description = transmute(image_base + 0x382720);
+    let quest_vtable = transmute(image_base + 0x1699720);//1.5.97: 0x15a1c98 -> 1.6.318: 0x1699720 -> addressLib ID: 195890 -> 1.6.323: 0x1699720
+    let quest_get_description = transmute(image_base + 0x398f70);//1.5.97: 0x382720 -> 1.6.318: 0x399000 -> addressLib ID: 25259 -> 1.6.323: 0x398f70
 
     let original_quest_load = patch_bytes(
         &(TESQuest::new_load as usize),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,44 @@ const DEBUG: bool = false;
 
 type PluginHandle = u32;
 
+//START AE CODE
+enum KVersionenum {
+    KVersion=1,
+}
+
+#[allow(non_snake_case)]
+#[repr(C)]
+pub struct SKSEPluginVersionData {
+    dataVersion: u32,
+
+    pluginVersion: u32,
+    name: [u8;256],
+
+    author: [u8;256],
+    supportEmail: [u8;256],
+
+    versionIndependence: u32,
+    compatibleVersions: [u32;16],
+
+    seVersionRequired: u32,
+}
+
+// const RUNTIME_VERSION_1_6_318: u32 = 0x010613E0;
+const RUNTIME_VERSION_1_6_323: u32 = 0x01061430;
+
+#[no_mangle]
+pub static SKSEPlugin_Version: SKSEPluginVersionData = SKSEPluginVersionData {
+    dataVersion: KVersionenum::KVersion as u32,
+    pluginVersion: 3,
+    name: *b"Skyrim Search\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0",
+    author: *b"qbx2 / lukasaldersley\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0",
+    supportEmail: *b"open a GitHub issue instead\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0",
+    versionIndependence: 0,
+    compatibleVersions: [RUNTIME_VERSION_1_6_323,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+    seVersionRequired: 0,
+};
+//END AE CODE
+
 #[repr(C)]
 pub struct SKSEInterface {
     skse_version: u32,
@@ -60,8 +98,7 @@ pub extern "C" fn SKSEPlugin_Query(skse: *const SKSEInterface, info: *mut Plugin
     let skse = unsafe { &*skse };
     let mut info = unsafe { &mut *info };
 
-    if skse.runtime_version != 0x01050610 {
-        // 1.5.97
+    if skse.runtime_version != RUNTIME_VERSION_1_6_323 {
         output_debug_string(
             format!("runtime_version mismatch: {:#x}", skse.runtime_version).as_str(),
         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,6 @@ pub struct SKSEPluginVersionData {
     seVersionRequired: u32,
 }
 
-// const RUNTIME_VERSION_1_6_318: u32 = 0x010613E0;
 const RUNTIME_VERSION_1_6_323: u32 = 0x01061430;
 
 const fn zero_pad_u8<const N: usize, const M: usize>(arr: &[u8; N]) -> [u8; M] {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,7 @@ const DEBUG: bool = false;
 
 type PluginHandle = u32;
 
-//START AE CODE
-enum KVersionenum {
+enum DataVersion {
     KVersion=1,
 }
 
@@ -30,13 +29,13 @@ pub struct SKSEPluginVersionData {
     dataVersion: u32,
 
     pluginVersion: u32,
-    name: [u8;256],
+    name: [u8; 256],
 
-    author: [u8;256],
-    supportEmail: [u8;256],
+    author: [u8; 256],
+    supportEmail: [u8; 256],
 
     versionIndependence: u32,
-    compatibleVersions: [u32;16],
+    compatibleVersions: [u32; 16],
 
     seVersionRequired: u32,
 }
@@ -44,18 +43,27 @@ pub struct SKSEPluginVersionData {
 // const RUNTIME_VERSION_1_6_318: u32 = 0x010613E0;
 const RUNTIME_VERSION_1_6_323: u32 = 0x01061430;
 
+const fn zero_pad_u8<const N: usize, const M: usize>(arr: &[u8; N]) -> [u8; M] {
+    let mut m = [0; M];
+    let mut i = 0;
+    while i < N {
+        m[i] = arr[i];
+        i += 1;
+    }
+    m
+}
+
 #[no_mangle]
 pub static SKSEPlugin_Version: SKSEPluginVersionData = SKSEPluginVersionData {
-    dataVersion: KVersionenum::KVersion as u32,
+    dataVersion: DataVersion::KVersion as u32,
     pluginVersion: 3,
-    name: *b"Skyrim Search\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0",
-    author: *b"qbx2 / lukasaldersley\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0",
-    supportEmail: *b"open a GitHub issue instead\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0",
+    name: zero_pad_u8(b"Skyrim Search SE\0"),
+    author: zero_pad_u8(b"qbx2, lukasaldersley\0"),
+    supportEmail: zero_pad_u8(b"open a GitHub issue on qbx2's GitHub\0"),
     versionIndependence: 0,
     compatibleVersions: [RUNTIME_VERSION_1_6_323,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
     seVersionRequired: 0,
 };
-//END AE CODE
 
 #[repr(C)]
 pub struct SKSEInterface {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ const DEBUG: bool = false;
 type PluginHandle = u32;
 
 enum DataVersion {
-    KVersion=1,
+    KVersion = 1,
 }
 
 #[allow(non_snake_case)]
@@ -60,7 +60,7 @@ pub static SKSEPlugin_Version: SKSEPluginVersionData = SKSEPluginVersionData {
     author: zero_pad_u8(b"qbx2, lukasaldersley\0"),
     supportEmail: zero_pad_u8(b"open a GitHub issue on qbx2's GitHub\0"),
     versionIndependence: 0,
-    compatibleVersions: [RUNTIME_VERSION_1_6_323,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+    compatibleVersions: [RUNTIME_VERSION_1_6_323, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
     seVersionRequired: 0,
 };
 


### PR DESCRIPTION
I've updated the code for Skyrim AE (runtimes 1.6.318 and 1.6.323)
.dlls for both versions do work and can be found in the releases section

However there's a problem with some of the original code since it uses NoneError which apparently was removed therefore I had to use an older version of Rust because I don't know how to fix that. I have included the IDs for Address Library in the comments but since this is rust I don't think I can implement the address Library.